### PR TITLE
swap inet_ntop and inet_pton to wchar versions

### DIFF
--- a/public/common/TracySocket.cpp
+++ b/public/common/TracySocket.cpp
@@ -603,8 +603,19 @@ bool UdpBroadcast::Open( const char* addr, uint16_t port )
     freeaddrinfo( res );
     if( !ptr ) return false;
 
-    m_sock = sock;
-    inet_pton( AF_INET, addr, &m_addr );
+	// @@ANET -- There is a symbol conflict between ws2_32.lib inet_pton and our internal, custom-built pythoncore.lib.
+	// which also defines inet_pton. This resulted in a linker error.
+	// Fixing the python source then recompiling that lib would be a big project. Quick fix, use wchar version of inet_pton 
+	// so there is no symbol confusion. Gross but effective.
+
+	// Original code
+	// inet_pton(AF_INET, addr, &m_addr);
+
+	wchar_t addrW[255] = { 0 };
+	mbstowcs(addrW, addr, 255);
+	InetPtonW(AF_INET, addrW, &m_addr);
+	// !@@ANET
+
     return true;
 }
 
@@ -648,7 +659,18 @@ void IpAddress::Set( const struct sockaddr& addr )
 #else
     auto ai = (const struct sockaddr_in*)&addr;
 #endif
-    inet_ntop( AF_INET, &ai->sin_addr, m_text, 17 );
+	// @@ANET -- There is a symbol conflict between ws2_32.lib inet_ntop and our internal, custom-built pythoncore.lib.
+	// which also defines inet_pton. This resulted in a linker error.
+	// Fixing the python source then recompiling that lib would be a big project. Quick fix, use wchar version of inet_ntop 
+	// so there is no symbol confusion. Gross but effective.
+
+	// Original code
+	// inet_ntop( AF_INET, &ai->sin_addr, m_text, 17 );
+	wchar_t wide[17] = { 0 };
+	InetNtopW(AF_INET, &ai->sin_addr, wide, 17);
+	wcstombs(m_text, wide, 17);
+	// !@@ANET
+
     m_number = ai->sin_addr.s_addr;
 }
 


### PR DESCRIPTION
There is a symbol conflict between ws2_32.lib inet_pton and our internal, custom-built pythoncore.lib. which also defines inet_pton. This resulted in a linker error. Fixing the python source then recompiling that lib would be a big project. Quick fix, use wchar version of inet_pton so there is no symbol confusion. Gross but effective.